### PR TITLE
adding new block hiding for gallery and best time to visit blocks

### DIFF
--- a/blocks/best-time-to-visit/render.php
+++ b/blocks/best-time-to-visit/render.php
@@ -110,24 +110,6 @@ if (! $has_content) {
     }
 
     // If no content on frontend, hide ancestor with specific class
-    // Generate unique ID for this instance
-    $unique_id = 'best-time-to-visit-empty-' . wp_unique_id();
-    $script_handle = 'asnz-best-time-hide-' . $unique_id;
-
-    // Register and enqueue inline script using WordPress script handling
-    wp_register_script($script_handle, false, array(), false, array('in_footer' => true));
-    wp_enqueue_script($script_handle);
-
-    // Add inline script to hide ancestor with .best-time-wrapper class
-    $inline_script = sprintf(
-        '(function(){var m=document.querySelector(".%s");if(m){var e=m.closest(".best-time-wrapper");if(e){e.style.display="none";}}})();',
-        esc_js($unique_id)
-    );
-    wp_add_inline_script($script_handle, $inline_script);
-
-    // Output marker with unique ID
-    echo '<div class="' . esc_attr($unique_id) . '" style="display:none;"></div>';
-
     return;
 }
 

--- a/blocks/envira-gallery/render.php
+++ b/blocks/envira-gallery/render.php
@@ -76,31 +76,6 @@ if (! $gallery_id && $is_editor) {
 
 // If no gallery ID on frontend, hide ancestor groups with CSS
 if (! $gallery_id) {
-    // Generate unique ID for this instance
-    $unique_id = 'envira-gallery-empty-' . wp_unique_id();
-
-    // Output marker with unique ID
-    echo '<div class="' . esc_attr($unique_id) . '" style="display:none;"></div>';
-
-    // Output inline script using direct output to avoid escaping
-    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo '<script>';
-    echo '(function(){';
-    echo 'var m=document.querySelector(".' . esc_js($unique_id) . '");';
-    echo 'if(m){';
-    echo 'var e=m.parentElement;';
-    echo 'var c=0;';
-    echo 'while(e&&c<3){';
-    echo 'if(e.classList.contains("wp-block-group")){';
-    echo 'e.style.display="none";';
-    echo 'c++;';
-    echo '}';
-    echo 'e=e.parentElement;';
-    echo '}';
-    echo '}';
-    echo '})();';
-    echo '</script>';
-    // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 
     return;
 }// Output the gallery section wrapper

--- a/blocks/envira-video-gallery/render.php
+++ b/blocks/envira-video-gallery/render.php
@@ -76,31 +76,6 @@ if (! $video_id && $is_editor) {
 
 // If no video ID on frontend, hide ancestor groups with CSS
 if (! $video_id) {
-    // Generate unique ID for this instance
-    $unique_id = 'envira-video-empty-' . wp_unique_id();
-
-    // Output marker with unique ID
-    echo '<div class="' . esc_attr($unique_id) . '" style="display:none;"></div>';
-
-    // Output inline script using direct output to avoid escaping
-    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo '<script>';
-    echo '(function(){';
-    echo 'var m=document.querySelector(".' . esc_js($unique_id) . '");';
-    echo 'if(m){';
-    echo 'var e=m.parentElement;';
-    echo 'var c=0;';
-    echo 'while(e&&c<3){';
-    echo 'if(e.classList.contains("wp-block-group")){';
-    echo 'e.style.display="none";';
-    echo 'c++;';
-    echo '}';
-    echo 'e=e.parentElement;';
-    echo '}';
-    echo '}';
-    echo '})();';
-    echo '</script>';
-    // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 
     return;
 }// Output the video gallery section wrapper

--- a/functions.php
+++ b/functions.php
@@ -351,3 +351,80 @@ add_filter(
     10,
     2
 );
+
+/**
+ * Hide wrapper blocks when they have no content.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $parsed_block  The parsed block.
+ * @param WP_Block $block_obj     The block object.
+ * @return string Modified block content.
+ */
+function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_obj)
+{
+    // Only process core/group blocks
+    if (! isset($parsed_block['blockName']) || 'core/group' !== $parsed_block['blockName']) {
+        return $block_content;
+    }
+
+    // Check for wrapper class
+    if (! isset($parsed_block['attrs']['className']) || empty($parsed_block['attrs']['className'])) {
+        return $block_content;
+    }
+
+    $classes = $parsed_block['attrs']['className'];
+
+    // 1. Envira Gallery Wrapper
+    if (strpos($classes, 'envira-gallery-wrapper') !== false) {
+        $gallery_id = 0;
+        if (function_exists('get_field')) {
+            $gallery_id = absint(get_field('envira_gallery'));
+        } else {
+            $gallery_id = absint(get_post_meta(get_the_ID(), 'envira_gallery', true));
+        }
+
+        if (! $gallery_id) {
+            return '';
+        }
+    }
+
+    // 2. Envira Video Gallery Wrapper
+    if (strpos($classes, 'envira-video-gallery-wrapper') !== false) {
+        $video_id = 0;
+        if (function_exists('get_field')) {
+            $video_id = absint(get_field('envira_video'));
+        } else {
+            $video_id = absint(get_post_meta(get_the_ID(), 'envira_video', true));
+        }
+
+        if (! $video_id) {
+            return '';
+        }
+    }
+
+    // 3. Best Time to Visit Wrapper
+    if (strpos($classes, 'best-time-wrapper') !== false) {
+        $has_content = false;
+
+        if (function_exists('get_field')) {
+            $best = get_field('best_time_to_visit');
+            $shoulder = get_field('shoulder_months_to_visit');
+            if (! empty($best) || ! empty($shoulder)) {
+                $has_content = true;
+            }
+        } else {
+            $best = get_post_meta(get_the_ID(), 'best_time_to_visit', true);
+            $shoulder = get_post_meta(get_the_ID(), 'shoulder_months_to_visit', true);
+            if (! empty($best) || ! empty($shoulder)) {
+                $has_content = true;
+            }
+        }
+
+        if (! $has_content) {
+            return '';
+        }
+    }
+
+    return $block_content;
+}
+add_filter('render_block', __NAMESPACE__ . '\asnz_maybe_hide_empty_wrappers', 10, 3);

--- a/functions.php
+++ b/functions.php
@@ -353,12 +353,20 @@ add_filter(
 );
 
 /**
- * Hide wrapper blocks when they have no content.
+ * Conditionally hide specific wrapper group blocks based on related field data.
+ *
+ * This targets `core/group` blocks that use one of the following wrapper classes:
+ * - `envira-gallery-wrapper` (hidden when the associated `envira_gallery` ACF field
+ *   or `envira_gallery` post meta is empty).
+ * - `envira-video-gallery-wrapper` (hidden when the associated `envira_video` ACF field
+ *   or `envira_video` post meta is empty).
+ * - `best-time-wrapper` (hidden when both `best_time_to_visit` and
+ *   `shoulder_months_to_visit` ACF fields or post meta are empty).
  *
  * @param string   $block_content The block content.
  * @param array    $parsed_block  The parsed block.
  * @param WP_Block $block_obj     The block object.
- * @return string Modified block content.
+ * @return string Modified block content, or an empty string when a wrapper is hidden.
  */
 function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_obj)
 {

--- a/functions.php
+++ b/functions.php
@@ -382,6 +382,15 @@ function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_ob
 
     $classes = $parsed_block['attrs']['className'];
 
+    // Early return if none of the target wrapper classes are present
+    if (
+        strpos($classes, 'envira-gallery-wrapper') === false &&
+        strpos($classes, 'envira-video-gallery-wrapper') === false &&
+        strpos($classes, 'best-time-wrapper') === false
+    ) {
+        return $block_content;
+    }
+
     // 1. Envira Gallery Wrapper
     if (strpos($classes, 'envira-gallery-wrapper') !== false) {
         $gallery_id = 0;

--- a/functions.php
+++ b/functions.php
@@ -384,15 +384,15 @@ function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_ob
 
     // Early return if none of the target wrapper classes are present
     if (
-        strpos($classes, 'envira-gallery-wrapper') === false &&
-        strpos($classes, 'envira-video-gallery-wrapper') === false &&
-        strpos($classes, 'best-time-wrapper') === false
+        ! str_contains($classes, 'envira-gallery-wrapper') &&
+        ! str_contains($classes, 'envira-video-gallery-wrapper') &&
+        ! str_contains($classes, 'best-time-wrapper')
     ) {
         return $block_content;
     }
 
     // 1. Envira Gallery Wrapper
-    if (strpos($classes, 'envira-gallery-wrapper') !== false) {
+    if (str_contains($classes, 'envira-gallery-wrapper')) {
         $gallery_id = 0;
         if (function_exists('get_field')) {
             $gallery_id = absint(get_field('envira_gallery'));
@@ -406,7 +406,7 @@ function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_ob
     }
 
     // 2. Envira Video Gallery Wrapper
-    if (strpos($classes, 'envira-video-gallery-wrapper') !== false) {
+    if (str_contains($classes, 'envira-video-gallery-wrapper')) {
         $video_id = 0;
         if (function_exists('get_field')) {
             $video_id = absint(get_field('envira_video'));
@@ -420,7 +420,7 @@ function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_ob
     }
 
     // 3. Best Time to Visit Wrapper
-    if (strpos($classes, 'best-time-wrapper') !== false) {
+    if (str_contains($classes, 'best-time-wrapper')) {
         $has_content = false;
         $best        = '';
         $shoulder    = '';

--- a/functions.php
+++ b/functions.php
@@ -413,21 +413,20 @@ function asnz_maybe_hide_empty_wrappers($block_content, $parsed_block, $block_ob
     // 3. Best Time to Visit Wrapper
     if (strpos($classes, 'best-time-wrapper') !== false) {
         $has_content = false;
+        $best        = '';
+        $shoulder    = '';
 
         if (function_exists('get_field')) {
-            $best = get_field('best_time_to_visit');
+            $best     = get_field('best_time_to_visit');
             $shoulder = get_field('shoulder_months_to_visit');
-            if (! empty($best) || ! empty($shoulder)) {
-                $has_content = true;
-            }
         } else {
-            $best = get_post_meta(get_the_ID(), 'best_time_to_visit', true);
+            $best     = get_post_meta(get_the_ID(), 'best_time_to_visit', true);
             $shoulder = get_post_meta(get_the_ID(), 'shoulder_months_to_visit', true);
-            if (! empty($best) || ! empty($shoulder)) {
-                $has_content = true;
-            }
         }
 
+        if (! empty($best) || ! empty($shoulder)) {
+            $has_content = true;
+        }
         if (! $has_content) {
             return '';
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -4043,6 +4044,7 @@
 			"integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.14.0"
 			}
@@ -4088,6 +4090,7 @@
 			"integrity": "sha512-I98SaDCar5lvEYl80ClRIUztH/hyWHR+I2f+5yTVp/MQ205HgYkA2b5mVdry/+nsEIrf8I65KA5V/PASx68MsQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
@@ -4301,6 +4304,7 @@
 			"integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "4.33.0",
 				"@typescript-eslint/types": "4.33.0",
@@ -5372,6 +5376,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5468,6 +5473,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -6447,6 +6453,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -8592,6 +8599,7 @@
 			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"array.prototype.flat": "^1.2.3",
 				"cheerio": "^1.0.0-rc.3",
@@ -8921,6 +8929,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "7.12.11",
 				"@eslint/eslintrc": "^0.4.3",
@@ -12247,6 +12256,7 @@
 			"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "^26.6.3",
 				"import-local": "^3.0.2",
@@ -15142,7 +15152,6 @@
 			"integrity": "sha512-bmyraQyO9wAyFwyr+ouMrbv3mFY/UZY8nlBorgqfTw735QtVfAUBKs7GrO/rvJByoKnnwzQIlIFq9WXdfkSL0g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -15175,8 +15184,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0",
-			"peer": true
+			"license": "Python-2.0"
 		},
 		"node_modules/npm-package-json-lint/node_modules/cosmiconfig": {
 			"version": "8.3.6",
@@ -15184,7 +15192,6 @@
 			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
@@ -15212,7 +15219,6 @@
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -15225,8 +15231,7 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
 			"version": "7.7.3",
@@ -15234,7 +15239,6 @@
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -15248,7 +15252,6 @@
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			},
@@ -16275,6 +16278,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -17250,6 +17254,7 @@
 			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"postcss": ">=5.0.0"
 			}
@@ -17726,6 +17731,7 @@
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -17740,6 +17746,7 @@
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -19004,6 +19011,7 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -20117,6 +20125,7 @@
 			"integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@stylelint/postcss-css-in-js": "^0.37.2",
 				"@stylelint/postcss-markdown": "^0.36.2",
@@ -20218,6 +20227,7 @@
 			"integrity": "sha512-CMI2wSHL+XVlNExpauy/+DbUcB/oUZLARDtMIXkpV/5yd8nthzylYd1cdHeDMJVBXeYHldsnebUX6MoV5zPW4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lodash": "^4.17.15",
 				"postcss-media-query-parser": "^0.2.3",
@@ -21765,7 +21775,6 @@
 			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
@@ -22023,6 +22032,7 @@
 			"integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -22109,6 +22119,7 @@
 			"integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^1.2.0",


### PR DESCRIPTION
---
name: "Pull Request"
about: "General changes, refactors, and maintenance"
title: "PR: Refactor empty block wrapper hiding to server-side"
labels: ["status:needs-review"]
---

# General Pull Request

> This repository enforces changelog, release, and label automation for all PRs and issues.  
> See the organisation-wide [Automation Governance & Release Strategy](https://github.com/lightspeedwp/.github/blob/HEAD/docs/AUTOMATION_GOVERNANCE.md) for contributor rules.


## Changelog

### Changed

- Refactored the logic for hiding empty `best-time-to-visit`, `envira-gallery`, and `envira-video-gallery` blocks. Moved from client-side inline JavaScript to a server-side `render_block` filter for better performance and cleaner DOM.

---

## Risk Assessment

**Risk Level:** Low

**Potential Impact:**

- If the logic fails, empty wrapper blocks might remain visible on the frontend (reverting to previous behavior but without the JS fix), or populated blocks might be accidentally hidden if the field detection is incorrect.

**Mitigation Steps:**

- Logic includes fallbacks for both ACF `get_field` and standard `get_post_meta`.
- Targeted specifically to `core/group` blocks with specific class names to avoid side effects on other blocks.

---

## How to Test

### Prerequisites

- A WordPress environment with the ASNZ theme active.
- ACF Pro and Envira Gallery plugins installed (optional, but helpful for full testing).

### Test Steps

1. **Step 1:** Create a new Page or Post.
2. **Step 2:** Add a Group block and give it the class `envira-gallery-wrapper`. Inside it, place the Envira Gallery block.
3. **Step 3:** Do **not** select a gallery for the post (ensure the ACF field/meta is empty).
4. **Step 4:** View the page on the frontend. Inspect the source code.
5. **Step 5:** Repeat the process for `envira-video-gallery-wrapper` (Envira Video block) and `best-time-wrapper` (Best Time to Visit block).

### Expected Results

- When the relevant data (Gallery ID, Video ID, or Best Time months) is empty, the wrapper Group block should be completely absent from the HTML source code.
- It should **not** be present with `display: none` (which was the old behavior).
- If data is added, the wrapper block should render normally.

### Edge Cases to Verify

- [ ] Verify that `core/paragraph` or other blocks inside the wrapper do not prevent it from being hidden if the main data is missing (the current logic hides the wrapper based on the *data*, not the inner blocks).
- [ ] Verify behavior when ACF is not active (should fall back to `get_post_meta` gracefully).

---

### Checklist (Global DoD / PR)

- [x] All AC met and demonstrated
- [ ] Tests added/updated (unit/E2E as appropriate)
- [ ] A11y considerations addressed where relevant
- [ ] Docs/readme/changelog updated (if user-facing)
- [ ] Security/perf impact reviewed where relevant
- [ ] Code/design reviews approved
- [ ] CI green; linked issues closed; release notes prepared (if shipping)
- [x] Risk assessment completed above
- [x] Testing instructions provided above

---

## References

- [Contribution Guidelines](../CONTRIBUTING.md)
- [Branching Strategy](../docs/BRANCHING_STRATEGY.md)
- [Automation Governance](../docs/AUTOMATION_GOVERNANCE.md)
- [PR Labels](../docs/PR_LAB---
name: "Pull Request"
about: "General changes, refactors, and maintenance"
title: "PR: Refactor empty block wrapper hiding to server-side"
labels: ["status:needs-review"]
---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed client-side inline scripts and hidden marker output; empty gallery/video/best-time wrappers no longer emit extra frontend markup.
  * Introduced server-side conditional suppression of empty core/group wrappers so empty blocks render nothing.

* **Bug Fixes**
  * Reduces frontend flicker and stray hidden elements when related content fields are absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->