### PR TITLE
Fix mega menu layout shift: measure panels at hydration, not window.load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 2026-07-27
+
+### Fixed
+
+- Mega menus no longer flash as narrow columns on load. Ollie Menu Designer ships no
+  CSS width for `.menu-width-full` panels — view.js measures the viewport and writes
+  the geometry inline, but defers that to the `window.load` event. On production
+  `load` waits on ~70 eager images, a YouTube embed, GTM, Chaty, Popup Maker and
+  Font Awesome from a third-party CDN, so panels measured 2.7s (at 1440px) as
+  shrink-wrapped `width:auto` boxes before snapping to full width. Locally `load`
+  fires almost immediately, which is why it only showed on live.
+  - `style.css` now states the panel's width and vertical offset up front, so a
+    pre-init panel is full-bleed and correctly placed rather than collapsed. Scoped
+    to `:not([style*='width'])` so it applies only before view.js has run.
+  - New `assets/js/mega-menu-init.js` triggers the plugin's own resize path once the
+    Interactivity store hydrates, bringing correct geometry ~2.4s forward, and
+    re-runs it after `load` because the plugin's load handler calls a reset-less
+    `adjustMegaMenu()` that would otherwise re-measure an already-corrected panel.
+
 ## 2025-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,26 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Mega menus no longer flash as narrow columns on load. Ollie Menu Designer ships no
-  CSS width for `.menu-width-full` panels — view.js measures the viewport and writes
-  the geometry inline, but defers that to the `window.load` event. On production
-  `load` waits on ~70 eager images, a YouTube embed, GTM, Chaty, Popup Maker and
-  Font Awesome from a third-party CDN, so panels measured 2.7s (at 1440px) as
-  shrink-wrapped `width:auto` boxes before snapping to full width. Locally `load`
-  fires almost immediately, which is why it only showed on live.
-  - `style.css` now states the panel's width and vertical offset up front, so a
-    pre-init panel is full-bleed and correctly placed rather than collapsed. Scoped
-    to `:not([style*='width'])` so it applies only before view.js has run.
-  - New `assets/js/mega-menu-init.js` triggers the plugin's own resize path once the
-    Interactivity store hydrates, bringing correct geometry ~2.4s forward, and
-    re-runs it after `load` because the plugin's load handler calls a reset-less
-    `adjustMegaMenu()` that would otherwise re-measure an already-corrected panel.
+- Mega menus no longer open as narrow columns overlapping the header. Ollie Menu
+  Designer ships no CSS width for `.menu-width-full` panels — view.js measures the
+  viewport and writes the geometry inline, but defers that to the `window.load`
+  event. On production `load` waits on ~70 eager images, a YouTube embed, GTM,
+  Chaty, Popup Maker and Font Awesome from a third-party CDN, so for 2.7s after
+  hydration a hovered panel opened as a ~626px shrink-wrapped box at the wrong
+  offset. Locally `load` fires immediately, which is why it only showed on live.
+  - New `assets/js/mega-menu-init.js` dispatches a single `resize` once the
+    Interactivity store hydrates, so the plugin measures via its own handler.
+    Measured at 1440px, the window in which a panel can open mis-sized drops from
+    2699ms to 18ms.
+  - It fires exactly once, at hydration, because the plugin's resize handler clears
+    the pending hover timeout — a resize inside the 150ms hover-open delay silently
+    cancels the open. It also clears the inline geometry on `load`, because the
+    plugin's load handler calls `adjustMegaMenu()` without the reset its resize
+    handler does and would otherwise re-measure an already-corrected panel.
+- Mega menu stacking now targets the Ollie panel element
+  (`.wp-block-ollie-mega-menu__menu-container`) instead of
+  `.wp-block-navigation__submenu-container`, which never matches these panels, and
+  drops the LSX sticky menu below it.
 
 ## 2025-10-17
 

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -93,5 +93,10 @@
 						return;
 					}
 				}
+			}, 0 );
+		},
+		// Capture runs this before the plugin's own bubble-phase load listener,
+		// regardless of which registered first.
 		{ once: true, capture: true }
+	);
 })();

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -93,8 +93,5 @@
 						return;
 					}
 				}
-			}, 0 );
-		},
-		{ once: true }
-	);
+		{ once: true, capture: true }
 })();

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -1,48 +1,32 @@
 /**
- * Apply Ollie mega menu panel geometry at hydration instead of at window.load.
+ * Make Ollie mega menus measure themselves at hydration instead of at window.load.
  *
  * Ollie Menu Designer ships no CSS width for `.menu-width-full` panels — view.js
- * measures the viewport and writes top/width/maxWidth/left as inline styles. It
- * runs that from `callbacks.initMenuLayout`, which defers to `window.load`:
+ * measures the viewport and writes the geometry inline, but defers that to the
+ * `window.load` event. On production `load` trails hydration by ~2.7s (images, a
+ * YouTube embed, GTM, Chaty, Popup Maker, Font Awesome from a third-party CDN), and
+ * a panel hovered in between opens as a shrink-wrapped column instead of a
+ * full-width bar. Locally `load` fires immediately, which is why it only showed on
+ * live. The plugin re-runs the same measurement from its own resize handler, so a
+ * single dispatched `resize` gets the correct geometry via the plugin's own path.
  *
- *     initMenuLayout() {
- *       document.readyState === 'complete'
- *         ? actions.adjustMegaMenu()
- *         : window.addEventListener( 'load', withScope( () => actions.adjustMegaMenu() ), { once: true } );
- *     }
+ * Three things are load-bearing here — please don't simplify them away:
  *
- * `load` waits on every image, iframe and script on the page. Measured on the
- * production home page at 1440px, the panels were still unsized 2.7s after
- * DOMContentLoaded — an absolutely positioned box with width:auto, shrink-wrapped
- * to a ~460-710px column at the wrong offset. Hover a nav item inside that window
- * and that is what you get. Locally `load` fires almost immediately, which is why
- * it only ever showed up on live.
+ * 1. Fire once, at hydration. `handleResize()` calls `clearHoverTimeout()`, so a
+ *    resize landing inside the plugin's 150ms hover-open delay silently cancels the
+ *    open. Hydration is the one safe moment: the handler that would start a hover
+ *    did not exist a tick earlier. `aria-expanded` is absent from the served markup
+ *    and bound via data-wp-bind, so its arrival marks that point.
  *
- * The plugin re-runs the same measurement from its own resize handler
- * (`data-wp-on-window--resize="actions.handleResize"` on each mega menu <li>), so
- * dispatching `resize` once the Interactivity store has hydrated applies the
- * plugin's own geometry, on the plugin's own code path, seconds earlier — no
- * forking or patching of the plugin's script module.
+ * 2. Clear the inline geometry on `load`. `adjustMegaMenu()` sets
+ *    `left = -rect.left`, which is only right while `left` is at its stylesheet
+ *    value. The plugin's load handler calls it without the reset its resize handler
+ *    does, so it would re-measure the panel we already corrected and push it back
+ *    off by its own offset. This listener is registered before hydration, hence
+ *    before the plugin's, so the plugin re-measures a clean panel.
  *
- * Two things make this less trivial than it sounds:
- *
- * 1. Hydration has no public "ready" signal, so phase one polls briefly and
- *    dispatches only while a full-width panel is still missing its inline width.
- *    In practice hydration lands within a tick or two.
- *
- * 2. `adjustMegaMenu()` is measure-and-negate: it reads the panel's current rect
- *    and sets `left = -rect.left`, which is only correct if `left` is still at its
- *    stylesheet value. `handleResize()` is safe because it calls
- *    `resetMenuPositionStyles()` first, but the `load` handler calls
- *    `adjustMegaMenu()` bare. So once we have positioned the panels early, the
- *    plugin's own load handler re-measures an already-corrected panel and pushes
- *    it back off by its own offset. Phase two runs after that handler and restores
- *    the correct geometry via the reset-first path.
- *
- * Both phases go through `handleResize()`, which is idempotent, so the worst case
- * is redundant work rather than a wrong position. If this script never runs at all
- * the panels still get sane width and vertical placement from the stylesheet — see
- * "Mega Menu: Full-width panel geometry before JS initialises" in style.css.
+ * 3. Keep the backstop. If that ordering ever fails, it repairs the geometry after
+ *    all load handlers have run. It only fires when the offset is actually wrong.
  *
  * @package asnz-block-theme
  */
@@ -50,68 +34,55 @@
 (function () {
 	'use strict';
 
-	var SELECTOR = '.wp-block-ollie-mega-menu__menu-container.menu-width-full';
-	var INTERVAL_MS = 100;
-	var MAX_ATTEMPTS = 8;
+	var panels = document.querySelectorAll(
+		'.wp-block-ollie-mega-menu__menu-container.menu-width-full'
+	);
+	var toggle = document.querySelector( '.wp-block-ollie-mega-menu__toggle' );
 
-	var panels = document.querySelectorAll( SELECTOR );
-
-	if ( ! panels.length ) {
+	// Nothing to bring forward if there are no full-width panels, or if the plugin
+	// already measured inline because the document was complete.
+	if ( ! panels.length || ! toggle || 'complete' === document.readyState ) {
 		return;
 	}
 
-	/**
-	 * Trigger the plugin's reset-then-measure path on every mega menu.
-	 */
 	function reflow() {
 		window.dispatchEvent( new Event( 'resize' ) );
 	}
 
-	/**
-	 * Whether view.js has written its inline width to every full-width panel.
-	 *
-	 * @return {boolean} True once all panels have been measured and sized.
-	 */
-	function isSized() {
-		for ( var i = 0; i < panels.length; i++ ) {
-			if ( ! panels[ i ].style.width ) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	// Phase one: nudge until the store has hydrated and the panels are sized.
-	var attempts = 0;
-
-	function nudgeUntilSized() {
-		// Either the plugin has sized them, or `load` has fired and its own
-		// handler has already done the work. Nothing left to do here.
-		if ( isSized() || 'complete' === document.readyState ) {
-			return;
-		}
-
-		if ( ++attempts > MAX_ATTEMPTS ) {
-			return;
-		}
-
+	if ( toggle.hasAttribute( 'aria-expanded' ) ) {
 		reflow();
-		window.setTimeout( nudgeUntilSized, INTERVAL_MS );
+	} else {
+		new window.MutationObserver( function ( mutations, observer ) {
+			observer.disconnect();
+			reflow();
+		} ).observe( toggle, {
+			attributes: true,
+			attributeFilter: [ 'aria-expanded' ],
+		} );
 	}
 
-	if ( 'complete' !== document.readyState ) {
-		window.setTimeout( nudgeUntilSized, 0 );
+	window.addEventListener(
+		'load',
+		function () {
+			var i;
 
-		// Phase two: the plugin's `load` handler runs a reset-less adjust that
-		// undoes phase one. setTimeout(0) from a load listener lands after every
-		// load handler, whatever order they registered in.
-		window.addEventListener(
-			'load',
-			function () {
-				window.setTimeout( reflow, 0 );
-			},
-			{ once: true }
-		);
-	}
+			for ( i = 0; i < panels.length; i++ ) {
+				panels[ i ].style.left = '';
+				panels[ i ].style.width = '';
+				panels[ i ].style.maxWidth = '';
+			}
+
+			window.setTimeout( function () {
+				for ( i = 0; i < panels.length; i++ ) {
+					// An empty offset, or the `0px` that measure-and-negate
+					// produces when it re-reads an already-corrected panel.
+					if ( ! panels[ i ].style.left || '0px' === panels[ i ].style.left ) {
+						reflow();
+						return;
+					}
+				}
+			}, 0 );
+		},
+		{ once: true }
+	);
 })();

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -37,11 +37,11 @@
 	var panels = document.querySelectorAll(
 		'.wp-block-ollie-mega-menu__menu-container.menu-width-full'
 	);
-	var toggle = document.querySelector( '.wp-block-ollie-mega-menu__toggle' );
+	var toggles = document.querySelectorAll( '.wp-block-ollie-mega-menu__toggle' );
 
 	// Nothing to bring forward if there are no full-width panels, or if the plugin
 	// already measured inline because the document was complete.
-	if ( ! panels.length || ! toggle || 'complete' === document.readyState ) {
+	if ( ! panels.length || ! toggles.length || 'complete' === document.readyState ) {
 		return;
 	}
 
@@ -49,13 +49,25 @@
 		window.dispatchEvent( new Event( 'resize' ) );
 	}
 
-	if ( toggle.hasAttribute( 'aria-expanded' ) ) {
-		reflow();
-	} else {
+	var pendingHydrations = toggles.length;
+
+	function markHydrated() {
+		pendingHydrations--;
+		if ( 0 === pendingHydrations ) {
+			reflow();
+		}
+	}
+
+	for ( var i = 0; i < toggles.length; i++ ) {
+		if ( toggles[ i ].hasAttribute( 'aria-expanded' ) ) {
+			markHydrated();
+			continue;
+		}
+
 		new window.MutationObserver( function ( mutations, observer ) {
 			observer.disconnect();
-			reflow();
-		} ).observe( toggle, {
+			markHydrated();
+		} ).observe( toggles[ i ], {
 			attributes: true,
 			attributeFilter: [ 'aria-expanded' ],
 		} );

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -1,0 +1,117 @@
+/**
+ * Apply Ollie mega menu panel geometry at hydration instead of at window.load.
+ *
+ * Ollie Menu Designer ships no CSS width for `.menu-width-full` panels — view.js
+ * measures the viewport and writes top/width/maxWidth/left as inline styles. It
+ * runs that from `callbacks.initMenuLayout`, which defers to `window.load`:
+ *
+ *     initMenuLayout() {
+ *       document.readyState === 'complete'
+ *         ? actions.adjustMegaMenu()
+ *         : window.addEventListener( 'load', withScope( () => actions.adjustMegaMenu() ), { once: true } );
+ *     }
+ *
+ * `load` waits on every image, iframe and script on the page. Measured on the
+ * production home page at 1440px, the panels were still unsized 2.7s after
+ * DOMContentLoaded — an absolutely positioned box with width:auto, shrink-wrapped
+ * to a ~460-710px column at the wrong offset. Hover a nav item inside that window
+ * and that is what you get. Locally `load` fires almost immediately, which is why
+ * it only ever showed up on live.
+ *
+ * The plugin re-runs the same measurement from its own resize handler
+ * (`data-wp-on-window--resize="actions.handleResize"` on each mega menu <li>), so
+ * dispatching `resize` once the Interactivity store has hydrated applies the
+ * plugin's own geometry, on the plugin's own code path, seconds earlier — no
+ * forking or patching of the plugin's script module.
+ *
+ * Two things make this less trivial than it sounds:
+ *
+ * 1. Hydration has no public "ready" signal, so phase one polls briefly and
+ *    dispatches only while a full-width panel is still missing its inline width.
+ *    In practice hydration lands within a tick or two.
+ *
+ * 2. `adjustMegaMenu()` is measure-and-negate: it reads the panel's current rect
+ *    and sets `left = -rect.left`, which is only correct if `left` is still at its
+ *    stylesheet value. `handleResize()` is safe because it calls
+ *    `resetMenuPositionStyles()` first, but the `load` handler calls
+ *    `adjustMegaMenu()` bare. So once we have positioned the panels early, the
+ *    plugin's own load handler re-measures an already-corrected panel and pushes
+ *    it back off by its own offset. Phase two runs after that handler and restores
+ *    the correct geometry via the reset-first path.
+ *
+ * Both phases go through `handleResize()`, which is idempotent, so the worst case
+ * is redundant work rather than a wrong position. If this script never runs at all
+ * the panels still get sane width and vertical placement from the stylesheet — see
+ * "Mega Menu: Full-width panel geometry before JS initialises" in style.css.
+ *
+ * @package asnz-block-theme
+ */
+
+(function () {
+	'use strict';
+
+	var SELECTOR = '.wp-block-ollie-mega-menu__menu-container.menu-width-full';
+	var INTERVAL_MS = 100;
+	var MAX_ATTEMPTS = 8;
+
+	var panels = document.querySelectorAll( SELECTOR );
+
+	if ( ! panels.length ) {
+		return;
+	}
+
+	/**
+	 * Trigger the plugin's reset-then-measure path on every mega menu.
+	 */
+	function reflow() {
+		window.dispatchEvent( new Event( 'resize' ) );
+	}
+
+	/**
+	 * Whether view.js has written its inline width to every full-width panel.
+	 *
+	 * @return {boolean} True once all panels have been measured and sized.
+	 */
+	function isSized() {
+		for ( var i = 0; i < panels.length; i++ ) {
+			if ( ! panels[ i ].style.width ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	// Phase one: nudge until the store has hydrated and the panels are sized.
+	var attempts = 0;
+
+	function nudgeUntilSized() {
+		// Either the plugin has sized them, or `load` has fired and its own
+		// handler has already done the work. Nothing left to do here.
+		if ( isSized() || 'complete' === document.readyState ) {
+			return;
+		}
+
+		if ( ++attempts > MAX_ATTEMPTS ) {
+			return;
+		}
+
+		reflow();
+		window.setTimeout( nudgeUntilSized, INTERVAL_MS );
+	}
+
+	if ( 'complete' !== document.readyState ) {
+		window.setTimeout( nudgeUntilSized, 0 );
+
+		// Phase two: the plugin's `load` handler runs a reset-less adjust that
+		// undoes phase one. setTimeout(0) from a load listener lands after every
+		// load handler, whatever order they registered in.
+		window.addEventListener(
+			'load',
+			function () {
+				window.setTimeout( reflow, 0 );
+			},
+			{ once: true }
+		);
+	}
+})();

--- a/functions.php
+++ b/functions.php
@@ -440,6 +440,41 @@ add_action('init', __NAMESPACE__ . '\register_mega_menu_style');
 
 
 /**
+ * Apply Ollie mega menu panel geometry at hydration instead of at window.load.
+ *
+ * Ollie Menu Designer sizes its full-width panels from view.js and defers that to
+ * the `window.load` event, which on this site lands 1-2s after first paint. Until
+ * then a `.menu-width-full` panel has no width from any stylesheet and collapses
+ * to a thin column. See assets/js/mega-menu-init.js for the full explanation; the
+ * matching CSS safety net lives in style.css under "Mega Menu: Full-width panel
+ * geometry before JS initialises".
+ *
+ * Only enqueued when the plugin providing the block is actually active, and only
+ * on the front end — the editor renders panels through its own code path.
+ */
+function enqueue_mega_menu_init()
+{
+    // The panels live in the header template part rather than post content, so
+    // gate on the block type existing at all, not on has_block().
+    if (! \WP_Block_Type_Registry::get_instance()->is_registered('ollie/mega-menu')) {
+        return;
+    }
+
+    wp_enqueue_script(
+        'asnz-mega-menu-init',
+        get_template_directory_uri() . '/assets/js/mega-menu-init.js',
+        array(),
+        wp_get_theme()->get('Version'),
+        array(
+            'in_footer' => true,
+            'strategy'  => 'defer',
+        )
+    );
+}
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_mega_menu_init');
+
+
+/**
  * Output TouristTrip JSON-LD on single tour pages.
  *
  * Yoast already emits the Organization / WebPage / BreadcrumbList graph, so this

--- a/functions.php
+++ b/functions.php
@@ -445,9 +445,7 @@ add_action('init', __NAMESPACE__ . '\register_mega_menu_style');
  * Ollie Menu Designer sizes its full-width panels from view.js and defers that to
  * the `window.load` event, which on this site lands 1-2s after first paint. Until
  * then a `.menu-width-full` panel has no width from any stylesheet and collapses
- * to a thin column. See assets/js/mega-menu-init.js for the full explanation; the
- * matching CSS safety net lives in style.css under "Mega Menu: Full-width panel
- * geometry before JS initialises".
+ * to a thin column. See assets/js/mega-menu-init.js for the full explanation.
  *
  * Only enqueued when the plugin providing the block is actually active, and only
  * on the front end — the editor renders panels through its own code path.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
  * Author: Lightspeed WP
  * Description: Modern WordPress block theme for African Safaris New Zealand.
  * Forked from the Ollie (OllieWP) theme by Lightspeed WP.
- * Version: 0.1.2
+ * Version: 0.1.3
  * Text Domain: asnz-block-theme
  */
 
@@ -669,6 +669,53 @@ header:has(> .is-position-sticky) {
     z-index: 999;
     /* now meaningful *within* the header context */
 }
+
+/* === Mega Menu: Full-width panel geometry before JS initialises === */
+
+/* Ollie Menu Designer only ships CSS widths for .menu-width-content and
+   .menu-width-wide. A .menu-width-full panel gets no width at all — its size
+   and offset are assigned by the plugin's view.js:
+
+       el.style.top    = `${el.dataset.topSpacing}px`;
+       el.style.width  = el.style.maxWidth = `${window.innerWidth}px`;
+       el.style.left   = `${-panelRect.left}px`;   // measure-and-negate
+
+   and that runs from `callbacks.initMenuLayout`, which defers the whole thing to
+   the `window.load` event. Until load fires the panel is position:absolute with
+   width:auto, so it shrink-wraps to its content — the thin-column flash. On
+   production `load` waits on ~70 eager images, a YouTube embed, GTM, Chaty,
+   Popup Maker and Font Awesome from an external CDN, so the wrong state is
+   visible for 1-2s whenever the nav is hovered early. Locally `load` fires
+   almost immediately, which is why this only ever showed up on live.
+
+   The panel's containing block is the mega menu <li> (core nav sets
+   position:relative on .wp-block-navigation-item), so the vertical target is
+   exactly `top: <top spacing>` and we can state that up front. The horizontal
+   target is viewport x=0, which is `left: -<the li's own x>` — not expressible
+   in CSS, so it stays view.js's job. mega-menu-init.js makes that happen at
+   hydration instead of at load; this block is the safety net that keeps the
+   panel usable (full-bleed, correctly placed vertically, just not yet pulled
+   left) if the script is blocked or errors.
+
+   The :not([style*='width']) guard scopes this to the pre-init state only: the
+   panels ship with no style attribute at all, and view.js always sets an inline
+   width on a full-width panel, so once it has run these declarations stop
+   applying and the plugin's own measured geometry takes over cleanly. */
+@media (min-width: 600px) {
+    /* 600px is the plugin's own desktop threshold (state.isDesktop). Below it
+       the panel becomes a full-screen overlay driven by the plugin's
+       .is-menu-open rules, which are !important and override everything here. */
+    .wp-block-ollie-mega-menu__menu-container.menu-width-full:not(
+            [style*='width']
+        ) {
+        /* Keep the plugin's position:absolute — `top` has to resolve against
+           the <li>, exactly as the value view.js later writes does. */
+        top: var(--asnz--mega-menu-top-spacing, 100px);
+        width: 100vw;
+        max-width: 100vw;
+    }
+}
+
 .wp-block-navigation.mega-menu-nav .wp-block-navigation__container {
     display: block;
 }

--- a/style.css
+++ b/style.css
@@ -670,52 +670,6 @@ header:has(> .is-position-sticky) {
     /* now meaningful *within* the header context */
 }
 
-/* === Mega Menu: Full-width panel geometry before JS initialises === */
-
-/* Ollie Menu Designer only ships CSS widths for .menu-width-content and
-   .menu-width-wide. A .menu-width-full panel gets no width at all — its size
-   and offset are assigned by the plugin's view.js:
-
-       el.style.top    = `${el.dataset.topSpacing}px`;
-       el.style.width  = el.style.maxWidth = `${window.innerWidth}px`;
-       el.style.left   = `${-panelRect.left}px`;   // measure-and-negate
-
-   and that runs from `callbacks.initMenuLayout`, which defers the whole thing to
-   the `window.load` event. Until load fires the panel is position:absolute with
-   width:auto, so it shrink-wraps to its content — the thin-column flash. On
-   production `load` waits on ~70 eager images, a YouTube embed, GTM, Chaty,
-   Popup Maker and Font Awesome from an external CDN, so the wrong state is
-   visible for 1-2s whenever the nav is hovered early. Locally `load` fires
-   almost immediately, which is why this only ever showed up on live.
-
-   The panel's containing block is the mega menu <li> (core nav sets
-   position:relative on .wp-block-navigation-item), so the vertical target is
-   exactly `top: <top spacing>` and we can state that up front. The horizontal
-   target is viewport x=0, which is `left: -<the li's own x>` — not expressible
-   in CSS, so it stays view.js's job. mega-menu-init.js makes that happen at
-   hydration instead of at load; this block is the safety net that keeps the
-   panel usable (full-bleed, correctly placed vertically, just not yet pulled
-   left) if the script is blocked or errors.
-
-   The :not([style*='width']) guard scopes this to the pre-init state only: the
-   panels ship with no style attribute at all, and view.js always sets an inline
-   width on a full-width panel, so once it has run these declarations stop
-   applying and the plugin's own measured geometry takes over cleanly. */
-@media (min-width: 600px) {
-    /* 600px is the plugin's own desktop threshold (state.isDesktop). Below it
-       the panel becomes a full-screen overlay driven by the plugin's
-       .is-menu-open rules, which are !important and override everything here. */
-    .wp-block-ollie-mega-menu__menu-container.menu-width-full:not(
-            [style*='width']
-        ) {
-        /* Keep the plugin's position:absolute — `top` has to resolve against
-           the <li>, exactly as the value view.js later writes does. */
-        top: var(--asnz--mega-menu-top-spacing, 100px);
-        width: 100vw;
-        max-width: 100vw;
-    }
-}
-
 .wp-block-navigation.mega-menu-nav .wp-block-navigation__container {
     display: block;
 }

--- a/style.css
+++ b/style.css
@@ -660,14 +660,19 @@ header:has(> .is-position-sticky) {
 /* The header context is what competes with page content — lift the whole thing */
 header:has(> .is-position-sticky) {
     z-index: 1000;
-    /* was 100 — must exceed the LSX sticky menu's effective z-index */
+    /* was 100 — must exceed the LSX sticky menu's z-index */
 }
 
-/* Put the z-index on the element that is actually positioned/pops down */
-.wp-block-navigation.mega-menu-nav .wp-block-navigation__submenu-container,
-.wp-block-navigation .has-child>.wp-block-navigation__submenu-container {
-    z-index: 999;
-    /* now meaningful *within* the header context */
+/* Mega menus here are Ollie Mega Menu blocks, not core nav submenus.
+   Target the actual panel element and lift it above the in-page sticky menu. */
+.wp-block-ollie-mega-menu__menu-container {
+    z-index: 1001 !important;
+}
+
+/* LSX secondary sticky menu ships with z-index:100 inline (same as the mega
+   panel's default), so it wins on DOM order. Push it below the mega menu. */
+.wp-block-lsx-tour-operator-sticky-menu {
+    z-index: 40 !important;
 }
 
 .wp-block-navigation.mega-menu-nav .wp-block-navigation__container {


### PR DESCRIPTION
## Problem

On live, hovering a mega menu shortly after page load opened it as a narrow column overlapping the header, snapping to full width a second or two later. It did not reproduce on dev.

Ollie Menu Designer ships **no CSS width** for `.menu-width-full` panels — `view.js` measures the viewport and writes the geometry as inline styles:

```js
el.style.top   = `${el.dataset.topSpacing}px`;
el.style.width = el.style.maxWidth = `${window.innerWidth}px`;
el.style.left  = `${-panelRect.left}px`;   // measure-and-negate
```

…but it defers all of that to the **`window.load`** event:

```js
initMenuLayout() {
  document.readyState === 'complete'
    ? actions.adjustMegaMenu()
    : window.addEventListener( 'load', withScope( () => actions.adjustMegaMenu() ), { once: true } );
}
```

Until `load` fires, the panel is `position: absolute` with `width: auto`, so it shrink-wraps to its content.

The window that matters is **hydration → load**, not first-paint → load: before hydration the nav has no event handlers, so nothing can open and nothing looks wrong. On the live home page that window measured **2699ms** — `load` waits on ~70 eager images, a YouTube embed, GTM (580KB / 1.13s), Chaty, Popup Maker and Font Awesome from `maxcdn.bootstrapcdn.com`. Locally `load` fires almost immediately, which is why it only ever showed on live.

## Fix

`assets/js/mega-menu-init.js` dispatches a **single `resize`** once the Interactivity store hydrates. The plugin already re-runs the same measurement from its own resize handler, so this gets the plugin's own geometry via the plugin's own code path — no forking or patching of its script module.

Three details are load-bearing and are commented as such in the file:

1. **Fire once, at hydration.** `handleResize()` calls `clearHoverTimeout()`, so a resize landing inside the plugin's 150ms hover-open delay *silently cancels the open*. An earlier polling version did exactly this and swallowed the first hover. Hydration is the one safe moment — the handler that would start a hover did not exist a tick earlier. Detected via the `aria-expanded` attribute the runtime binds onto the toggle.
2. **Clear the inline geometry on `load`.** `adjustMegaMenu()` is measure-and-negate, correct only while `left` is at its stylesheet value. The plugin's load handler calls it *without* the reset its resize handler does, so it would re-measure the panel we already corrected and push it back off by its own offset. This listener registers before hydration, hence before the plugin's.
3. **Keep the backstop.** If that ordering ever fails, it repairs the geometry after all load handlers have run, and only when the offset is actually wrong.

No CSS is involved. An earlier revision added a pre-init `@media` block, but since the script now lands at hydration the CSS never had a visible effect, and its hardcoded `top` duplicated the block's editor-controlled Top Spacing — so it was dropped.

Also swaps the mega menu z-index rule onto `.wp-block-ollie-mega-menu__menu-container`. The previous selector, `.wp-block-navigation__submenu-container`, never matches these panels — they are Ollie blocks, not core nav submenus.

## Verification

Measured with headless Chrome over CDP at 1440x900, dev vs live, sequential runs:

| | Live (no fix) | Dev v2 (fixed) |
|---|---|---|
| Hydration | 3615ms | 3890ms |
| `window.load` | 6285ms | 5805ms |
| Geometry correct | 6314ms | **3908ms** |
| **Window where a panel can open mis-sized** | **2699ms** | **18ms** |
| Synthetic resizes | 0 | 1 |

On live, correct geometry arrives 29ms *after* `load`. On dev it arrives 18ms after *hydration* — 1897ms *before* `load`.

Hovering "Destinations" pre-`load`, same point in the lifecycle:

- **Live:** `top=42.8, left=450.2, width=626.4` — narrow column over the nav
- **Dev:** `top=142.8, left=0, width=1440` — correct, and the hover is not swallowed

Also checked:

- **No transient at `load`** — the only geometry transition in the dev timeline is the single jump to correct.
- **Viewports 390–1920px** — no horizontal overflow at any width (`body.scrollWidth == clientWidth`); below ~1200px the nav is collapsed and the plugin's `!important` overlay rules govern, untouched.
- **z-index on a tour page** with the LSX sticky menu pinned and a 44.8px overlap: `elementFromPoint` at three x-positions across the overlap band returns the mega panel both with and without the rules. See note below.

## Notes for review

- **The z-index rules are currently redundant.** `header { z-index: 1000 }` already beats the sticky menu's `100`, and that header rule predates this work. They are harmless and arguably worth keeping as defence-in-depth — and `.wp-block-ollie-mega-menu__menu-container` is genuinely the right element to target — but if the original symptom is gone, the `!important` pair could be dropped.
- **Top Spacing is still `100`**, so the panel sits 2–6px above the header bottom from 1280px up (flush at 1200). It needs ~106 at 1440+, but no single value works everywhere because the header itself grows ~7px across that range. Editor-side, not code.
- **Lint has not run** — no `node_modules` in the theme, so `wp-scripts lint-style` / `lint-js` were unavailable. `node --check` passes.
- **Root cause is untouched.** This shrinks the window rather than removing it. Lazy-loading the below-fold images and deferring GTM would cut `load` itself — separate work.
- **Unrelated pre-existing error:** `Uncaught ReferenceError: fUtil is not defined` from the FacetWP inline script in `functions.php`. The `function_exists('FWP')` guard passes because the plugin is active, but `fUtil()` only exists where FacetWP enqueues its JS, so the homepage throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)