### PR TITLE
fix(theme): let the load backstop check open mega-menu panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 2026-07-28
+
+### Fixed
+
+- Mega menu panel permanently offset by its own x-position when a visitor opened it
+  before `window.load`. Reported by the client, reproduced at 1920px: open the page
+  fresh, hover a mega menu quickly enough to catch it, and the panel renders starting
+  at its nav item instead of the viewport edge, overflowing right with the last column
+  cut off. It stays wrong until a reload.
+  - Cause: 0.1.6 added a guard skipping any panel with `aria-expanded="true"` in the
+    `load` handler, to avoid a visible reset of an open panel. The guard was applied to
+    the backstop as well as the clear loop, which removed *both* defences from the one
+    panel a visitor can actually see. The plugin's own `load` handler still runs its
+    reset-less `adjustMegaMenu()` on it, re-measures a panel we already corrected
+    (`menuRect.left === 0`) and writes `left: 0px` — and with the backstop also
+    skipping it, nothing ever detected or repaired that.
+  - Fix: the backstop now checks every panel, including an open one. The clear loop
+    still skips open panels, so 0.1.6's reason for the guard is preserved. Repairing an
+    open panel costs one frame at the wrong offset; leaving it broken cost the whole
+    pageview.
+  - Verified A/B against live at 1920px with a menu held open through `load`: deployed
+    build leaves exactly one broken panel (the open one, `left: 0px`), this build
+    leaves none.
+
 ## 2026-07-27 (5)
 
 ### Fixed

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -140,11 +140,16 @@
 				panels[ i ].style.maxWidth = '';
 			}
 
+			// The backstop deliberately checks EVERY panel, including an open one
+			// skipped above. Skipping it here too left the open panel with no
+			// defence at all: the plugin's load handler still runs its reset-less
+			// adjustMegaMenu() on it, re-measures a panel we already corrected,
+			// and writes left:0px — which then went undetected, so the panel the
+			// visitor is actually looking at stayed offset by its own x until a
+			// reload. Repairing it costs a frame at the wrong offset; leaving it
+			// broken costs the whole pageview.
 			window.setTimeout( function () {
 				for ( i = 0; i < panels.length; i++ ) {
-					if ( toggles[ i ] && 'true' === toggles[ i ].getAttribute( 'aria-expanded' ) ) {
-						continue;
-					}
 					// An empty offset, or the `0px` that measure-and-negate
 					// produces when it re-reads an already-corrected panel.
 					if ( ! panels[ i ].style.left || '0px' === panels[ i ].style.left ) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
  * Author: Lightspeed WP
  * Description: Modern WordPress block theme for African Safaris New Zealand.
  * Forked from the Ollie (OllieWP) theme by Lightspeed WP.
- * Version: 0.1.9
+ * Version: 0.1.10
  * Text Domain: asnz-block-theme
  */
 


### PR DESCRIPTION
## The bug

Client report, reproduced at 1920px: open the page fresh, hover a mega menu quickly enough to catch it, and the panel renders starting at its **nav item's x** instead of the viewport edge — overflowing right with the last column cut off. It **stays wrong until a reload**.

## Cause

`22f8f77` (0.1.6) added a guard skipping any panel with `aria-expanded="true"` in the `load` handler, so an open panel would not be visibly reset. Correct intent — but it was applied to the **backstop** as well as the clear loop, which stripped *both* defences from the one panel a visitor can actually see:

1. Visitor hovers after hydration but before `load` → panel opens, `aria-expanded="true"`.
2. `load` fires. The guard skips that panel, so its correct `left: -841.469px` is left in place.
3. The plugin's own `load` handler still runs its reset-less `adjustMegaMenu()` on **every** panel. On the skipped one it re-measures a panel we already corrected — `menuRect.left === 0` — and writes **`left: 0px`**.
4. The backstop skips the same panel, so the `0px` is never detected and never repaired.
5. Panel sits at its nav item's x, ~viewport wide, overflowing right. Permanent until reload or a real window resize.

Confirmed by tracing the panel's `style` attribute through `load`: the resulting property order is `top; left; width; max-width` with `left` never removed — the fingerprint of `applyMenuWidth` clearing width/max-width while `left` survived, which is exactly what skipping the clear produces.

The clincher is a single run with a perfect internal control — state captured at `load`, before the theme handler ran:

```
panel[0] "Destinations"         aria-expanded=false  -> cleared -> left=0            ok
panel[1] "Safaris & Tours"      aria-expanded=true   -> SKIPPED -> left=841.5 (0px)  BROKEN
panel[2] "Planning your Safari" aria-expanded=false  -> cleared -> left=0            ok
panel[3] "About"                aria-expanded=false  -> cleared -> left=0            ok
panel[4] "Blog"                 aria-expanded=false  -> cleared -> left=0            ok
```

Exactly one panel breaks: the open one. Which is the only one the visitor can see, so whenever it triggers it is guaranteed visible — and being a narrow timing window, it is hard to catch but sticks once caught.

## Fix

One change: the backstop now checks **every** panel, including an open one.

The clear loop still skips open panels, so 0.1.6's reason for the guard is preserved — an open panel is still never cleared out from under the visitor. Repairing it costs one frame at the wrong offset before `handleResize`'s rAF resets and re-measures; leaving it broken cost the whole pageview.

## Verification

A/B against live at 1920px, same harness, menu held open through `load`. Only difference is the script — the deployed one blocked and the local build injected in its place:

| | panel[1] "Safaris & Tours" | broken panels |
|---|---|---|
| deployed (0.1.9) | `left=841.5`, inline `0px` | **1** |
| this build | `left=0`, inline `-841.469px` | **0** |

All four closed panels correct in both runs.

`node --check` passes. Version 0.1.9 → 0.1.10.

## Two related things NOT changed here

Both are pre-existing and neither is currently causing a fault, so they are out of scope for a fix the client is waiting on — but they are worth a follow-up:

1. **`capture: true` does not do what its comment claims.** Tracing shows load handlers firing in pure registration order — the theme's, registered at 3674ms, ran before the plugin's five registered at 5142ms. The `load` event is dispatched at `window` with the legacy-target-override flag, so `window` is the only object in the propagation path; the listener is *at target*, and at-target listeners run in registration order regardless of the capture flag. It works only because the theme script registers before hydration — the original ordering assumption. The comment promises a guarantee that isn't there.
2. **The `toggles[i]` / `panels[i]` pairing is coincidental.** `panels` filters `.menu-width-full`; `toggles` does not filter at all. Today both are 5, in matching order, so it works. Set any one mega menu to Content or Wide width in the editor and the arrays misalign, and the clear loop starts consulting the wrong toggle — reintroducing this class of bug. Pairing each panel with its own toggle (e.g. `panel.previousElementSibling` or `closest('.wp-block-ollie-mega-menu')`) would make it structural rather than positional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)