### PR TITLE
fix(theme): pair mega-menu panels with their own toggle, not by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 2026-07-28 (2)
+
+### Fixed
+
+- Pair each mega-menu panel with its own toggle structurally instead of by list
+  index. `panels` is filtered to `.menu-width-full` while `toggles` is not, so
+  `toggles[ i ]` only described `panels[ i ]` while every mega menu happened to be
+  full-width — true today, but set one to Content or Wide in the editor and every
+  index shifts. Demonstrated by setting "Destinations" to Content width with "About"
+  open: `panels` becomes 4 against 5 toggles, and the open About panel reads as
+  closed (so it would be cleared mid-view) while the closed Blog panel reads as open
+  (so it would be skipped). The structural lookup — `closest( '.wp-block-ollie-mega-menu' )`
+  then its own toggle — gets both right.
+
+- Corrected the `capture: true` comment on the `load` listener. It claimed capture
+  runs the handler ahead of the plugin's regardless of registration order; it does
+  not. `load` is fired at `window` with the legacy-target-override flag, so `window`
+  is the only object in the propagation path — the listener is `AT_TARGET`, and
+  at-target listeners run in registration order whatever the capture flag says.
+  Running first depends on this script executing before hydration (measured: theme
+  registers at ~3.7s, the plugin's five at ~5.1s), with the backstop as the covering
+  guarantee. Behaviour unchanged; only the comment was wrong, and it was the kind of
+  wrong that invites someone to lean on it.
+
+### Resolved without a code change
+
+- The "About panel opens empty, only a decorative icon" report (see (4) and (5) under
+  2026-07-27) is the *same defect* as the client's misalignment report, already fixed
+  in 0.1.10 — not a separate hydration or collapse bug. Proof: force `left: 0px` (what
+  the defect wrote) on the About panel at 1440px and the panel spans x=983→2408. Its
+  layout is icon-column-first, so column 1 stays on screen at x=1075 while column 2 —
+  all 13 links — lands at x=1502, past the 1440px edge. Measured `iconOnScreen: true`,
+  `visibleLinks: 0/13`: exactly "only a decorative icon visible, no links/text".
+  - So the 0.1.8 "collapsed panel" recovery was chasing a symptom of the `left: 0px`
+    write, which is why a fixed-delay re-check could never fix it and instead broke
+    hover-open. Confirmed unreproducible on 0.1.10 across 1200-1920px and three
+    cold-cache loads hovering About at hydration (13/13 links every time).
+  - The 0x0-with-content measurement in that report is explained too: below ~1100px
+    the desktop nav collapses to the mobile overlay, so every panel measures 0x0 at
+    `visibility: hidden` while still holding its links. That is normal, not a fault.
+
 ## 2026-07-28
 
 ### Fixed

--- a/assets/js/mega-menu-init.js
+++ b/assets/js/mega-menu-init.js
@@ -54,6 +54,28 @@
 	var toggles = document.querySelectorAll( '.wp-block-ollie-mega-menu__toggle' );
 
 	/**
+	 * Whether a panel's own mega menu is currently open.
+	 *
+	 * Pair a panel with its toggle structurally, never by index. `panels` is
+	 * filtered to `.menu-width-full` while `toggles` is not, so `toggles[ i ]`
+	 * only describes `panels[ i ]` for as long as every mega menu happens to be
+	 * full-width. Set one to Content or Wide in the editor and index pairing
+	 * silently starts consulting the wrong toggle — which is how an open panel
+	 * ends up treated as closed (and vice versa).
+	 *
+	 * @param {Element} panel The `.menu-width-full` panel element.
+	 * @return {boolean} True when this panel's menu is open.
+	 */
+	function isPanelOpen( panel ) {
+		var item = panel.closest( '.wp-block-ollie-mega-menu' );
+		var toggle = item
+			? item.querySelector( '.wp-block-ollie-mega-menu__toggle' )
+			: null;
+
+		return !! toggle && 'true' === toggle.getAttribute( 'aria-expanded' );
+	}
+
+	/**
 	 * Clamp a full-width panel's inline width/max-width to the actual visible
 	 * viewport (`clientWidth`) whenever the plugin (or our own reflow) sets it
 	 * from `window.innerWidth`, which over-shoots by the scrollbar's width.
@@ -132,7 +154,7 @@
 			// cleared so the plugin can re-measure them cleanly before they're
 			// ever shown.
 			for ( i = 0; i < panels.length; i++ ) {
-				if ( toggles[ i ] && 'true' === toggles[ i ].getAttribute( 'aria-expanded' ) ) {
+				if ( isPanelOpen( panels[ i ] ) ) {
 					continue;
 				}
 				panels[ i ].style.left = '';
@@ -159,8 +181,13 @@
 				}
 			}, 0 );
 		},
-		// Capture runs this before the plugin's own bubble-phase load listener,
-		// regardless of which registered first.
+		// NB: capture does NOT reorder this ahead of the plugin's listener. `load`
+		// is fired at `window` with the legacy-target-override flag, so `window`
+		// is the only object in the propagation path — the listener is AT_TARGET,
+		// and at-target listeners run in registration order whatever the capture
+		// flag says. Running first depends on this script executing before
+		// hydration (verified: theme registers at ~3.7s, plugin's at ~5.1s), and
+		// the backstop below is what covers us if that ever stops holding.
 		{ once: true, capture: true }
 	);
 })();

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
  * Author: Lightspeed WP
  * Description: Modern WordPress block theme for African Safaris New Zealand.
  * Forked from the Ollie (OllieWP) theme by Lightspeed WP.
- * Version: 0.1.10
+ * Version: 0.1.11
  * Text Domain: asnz-block-theme
  */
 


### PR DESCRIPTION
> **Stacked on #225** — this branch contains #225's commit, so its diff shows both. Merge #225 first, or merge this and #225 closes with it. I kept them separate so #225 stays byte-identical to what was tested on dev.

Two follow-ups from the #225 investigation, plus one report closed out without code.

## 1. Index pairing between `panels` and `toggles` (real, latent)

`panels` is filtered to `.menu-width-full`; `toggles` is not. So `toggles[ i ]` only describes `panels[ i ]` for as long as **every** mega menu happens to be full-width. That's true today — 5 and 5, matching order — so it works by luck, not by construction. Set one menu to Content or Wide width in the editor and every index shifts.

Demonstrated on dev by setting "Destinations" to Content width with "About" open, so `panels` becomes 4 against 5 toggles:

```
panel                | OLD toggles[i] says                  | NEW structural | agree?
Safaris & Tours      | open=false (read "Destinations")      | open=false     | yes
Planning your Safari | open=false (read "Safaris & To…")     | open=false     | yes
About                | open=false (read "Planning you…")    | open=true      | *** NO — old is WRONG ***
Blog                 | open=true  (read "About")            | open=false     | *** NO — old is WRONG ***
```

Consequences of those two errors: the genuinely-open **About** panel reads as closed, so it gets cleared out from under the visitor (the visible reset 0.1.6 existed to prevent); and the closed **Blog** panel reads as open, so it gets skipped (the exact shape of the 0.1.9 defect #225 fixed).

`isPanelOpen()` now resolves each panel's own toggle via `closest( '.wp-block-ollie-mega-menu' )`, so it can't drift. `toggles` is still used for hydration counting, which is correct — that loop iterates `toggles` itself rather than cross-indexing.

## 2. The `capture: true` comment was wrong

It claimed capture runs the handler ahead of the plugin's "regardless of which registered first". It does not. `load` is fired at `window` with the **legacy-target-override** flag, so `window` is the only object in the propagation path — the listener is `AT_TARGET`, and at-target listeners run in **registration order** whatever the capture flag says.

Tracing confirms it: theme handler registered at ~3674 ms ran before the plugin's five registered at ~5142 ms — registration order, not capture. Running first genuinely depends on this script executing before hydration, and the backstop is what covers us if that stops holding. Behaviour unchanged; only the comment is corrected — it was the kind of wrong that invites someone to lean on a guarantee that isn't there.

## 3. The "About panel opens empty" report — same defect as #225, no code needed

The report (0.1.7, and the reverted 0.1.8 recovery) described the About panel opening with **only a decorative icon, no links or text**. It's not a hydration race or a collapse — it's the **same `left: 0px` write** #225 fixed, presenting differently because of About's layout.

Forcing `left: 0px` on the About panel at 1440px:

```
panel spans x=983 → 2408
col1 (icon)         left=1075  onScreen=true
col2 (all content)  left=1502  onScreen=false
iconOnScreen: true   visibleLinks: 0/13
```

About is the only panel whose first column is the decorative SVG and whose second column holds everything else. Shift it right by its own offset (982 px) and the icon column is the only thing left inside the viewport while all 13 links sit past the right edge. That is precisely "opens visually empty, only a decorative icon visible" — and a screenshot of the simulated state matches the original description exactly.

Which explains why 0.1.8's fixed-delay re-check could never work: it was re-checking a symptom of a bad `left`, so it fired inside the plugin's 100-175 ms visibility transition, read a legitimately-hidden panel as collapsed, and cancelled the hover-open — breaking the case it was trying to catch.

Confirmed **unreproducible on 0.1.10**: all 13 links render at 1200/1280/1366/1440/1600/1920 px, and across three cold-cache loads hovering About the instant it hydrates (one of them pre-`load`), 13/13 links every time.

The "0x0 box while still containing real content (12 links)" measurement in that report is also explained: below ~1100 px the desktop nav collapses into the mobile overlay, so every panel measures 0x0 at `visibility: hidden` while still holding its links. Normal, not a fault — worth knowing before it gets re-reported.

## Verification

- Mixed-width simulation above: structural lookup correct on all 4 panels; index pairing wrong on 2.
- Regression check for #225 on live with a menu **held open through `load`**: **0 broken panels**, all five at `left=0` with correct inline offsets.
- `node --check` passes.
- Version 0.1.10 → 0.1.11.

## Not addressed

The About panel ships a **60 KB inline SVG with 128 `<path>` elements** rendered at 91×79 px — 86% of that template part's 70 KB, and it's in the header so it parses on **every** page load. Not a correctness issue and not why the panel looked empty, but it's the single largest chunk of markup on the site and an obvious optimisation (a sized `<img>`/sprite, or a simplified path set). Separate change, happy to do it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)